### PR TITLE
Fix blurry font on High-DPI displays

### DIFF
--- a/ProxySwitcher/ProxySwitcher.csproj
+++ b/ProxySwitcher/ProxySwitcher.csproj
@@ -8,9 +8,10 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>ProxySwitcher</RootNamespace>
     <AssemblyName>ProxySwitcher</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -21,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -30,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -68,6 +71,7 @@
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
+      <DesignTime>True</DesignTime>
     </Compile>
     <None Include="app.config" />
     <None Include="Properties\Settings.settings">

--- a/ProxySwitcher/app.config
+++ b/ProxySwitcher/app.config
@@ -1,10 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
-        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
-            <section name="ProxySwitcher.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+            <section name="ProxySwitcher.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
         </sectionGroup>
     </configSections>
+	<System.Windows.Forms.ApplicationConfigurationSection>
+		<add key="DpiAwareness" value="PerMonitorV2"/>
+	</System.Windows.Forms.ApplicationConfigurationSection>
     <userSettings>
         <ProxySwitcher.Properties.Settings>
             <setting name="FirstMinimize" serializeAs="String">
@@ -15,4 +18,4 @@
             </setting>
         </ProxySwitcher.Properties.Settings>
     </userSettings>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>


### PR DESCRIPTION
Windows Form applications need a bit of configuration to support High-DPI displays; otherwise, some fonts will look blurry. The problem is fixed in this PR, and the .NET version has been increased to 4.8.

![Before](https://github.com/HirbodBehnam/Proxy-Switcher/assets/22544859/a0dee7d0-8079-481d-8a27-a8f5e8a566fe)
![After](https://github.com/HirbodBehnam/Proxy-Switcher/assets/22544859/0ab22a1e-eb9c-430c-a82d-b610819e4e9a)
